### PR TITLE
Fix urls.py

### DIFF
--- a/src/project_name/urls.py
+++ b/src/project_name/urls.py
@@ -19,4 +19,4 @@ urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 if settings.DEBUG:
     import debug_toolbar
-    urlpatterns += url(r'^__debug__/', include(debug_toolbar.urls)),
+    urlpatterns += [url(r'^__debug__/', include(debug_toolbar.urls)),]


### PR DESCRIPTION
TypeError: 'RegexURLResolver' object is not iterable

This error occurred at line number 22 because += only works on iterables. Must have been a typo.